### PR TITLE
fix: improves css for previews

### DIFF
--- a/django_grouper/templates/django_grouper/group.html
+++ b/django_grouper/templates/django_grouper/group.html
@@ -41,11 +41,21 @@
   left: 0;
   right: 0;
   bottom: 0;
-  height: 10em;
+  height: 15em;
   background-color: #F5F5F5;
   border-top: 1px solid black;
   overflow: scroll;
+  z-index: 100000;
 }
+#current-preview-area, #primary-preview-area {
+  max-width: 48%;
+  overflow-wrap: break-word;
+  height: 100%;
+  word-wrap: break-word;
+  word-break: break-word;
+  height: 100%;
+  overflow: auto;
+};
 .preview-content {
   border: 1px solid black;
 }
@@ -53,7 +63,7 @@
   margin-top: 40em !important;
 }
 .relations {
-  white-space: pre;
+  white-space: pre-wrap;
 }
         </style>
         <div class="container">


### PR DESCRIPTION
uses wrap to break long text (instead of overflowing); increases
the z-index of the preview panes to ensure that it is above all other
content.