### PR TITLE
fix(templates): try different detail url routes

### DIFF
--- a/django_grouper/templates/django_grouper/grouper.html
+++ b/django_grouper/templates/django_grouper/grouper.html
@@ -18,7 +18,11 @@ summary {
                     <details>
                         <summary>{{ entries|length }} occurences</summary>
                         {% for entry in entries %}
-                            <a href="{% url "apis_core:apis_entities:generic_entities_detail_view" content_type.model entry.pk %}">{{ entry.pk }}</a>,
+                            {% url "apis_core:generic:detail" content_type entry.pk as detail_url %}
+                            {% if not detail_url %}
+                                {% url "apis_core:apis_entities:generic_entities_detail_view" content_type.model entry.pk as detail_url %}
+                            {% endif %}
+                            {% if detail_url %}<a href="{{ detail_url }}">{{ entry.pk }}</a>,{% endif %}
                         {% endfor %}
                     </details>
                 </li>


### PR DESCRIPTION
The "apis_core:apis_entities:generic_entities_detail_view" route is only
available in very old APIS deployments. Instead of hardcoding the route
we try the newer one first and use the older one only as fallback.
Additionaly, the url is only used if it resolves.
