### PR TITLE
feat: replace hardcoded merge functionality with signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,18 @@ Group Django model instances based on similar fields
 If you define a `GROUP_FILTER` in you settings, the queryset in the `/grouper` view will be passed through this filter. The filter is expected to
 be a callable and will receive the queryset and the request as parameters. This means you can pass the queryset together with the request to a
 django-filter filter.
+
+The `/group` view lets you select which objects of a list should be merged. If
+you double click an object, it will become the primary, a single click marks an
+object as secondary. There can be one primary and multiple secondaries. The
+primary and the list of secondaries are then passed to the `trigger_merge`
+signal. You can use this method to implement a custom merge method.
+
+```
+from django_grouper.signals import trigger_merge
+
+
+@receiver(trigger_merge)
+def react_on_merge_trigger(sender, primary, secondaries, **kwargs):
+    primary.merge(secondaries)
+```

--- a/django_grouper/signals.py
+++ b/django_grouper/signals.py
@@ -1,0 +1,3 @@
+import django.dispatch
+
+trigger_merge = django.dispatch.Signal()


### PR DESCRIPTION
This way the projects can implement their own merge functionality by
liseting for the `trigger_merge` signal.
